### PR TITLE
ios_android_pwa_및_apk_설정 : feat : pwa 상단 인디케이터 색상 설정 및 하단 여백 추가 https…

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,19 +45,28 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-      <html lang="ko" className={`${pacifico.variable}`}>
-      <meta name="mobile-web-app-capable" content="yes" />
-      <meta name="apple-mobile-web-app-capable" content="yes" />
-      <meta name="apple-mobile-web-app-status-bar-style" content="default" />
-      <meta name="format-detection" content="telephone=no" />
-      <body
-          // Tailwind 전역 클래스: 안전한 영역(p-safe)과 가독성을 위한 기본 레이아웃
-          className="min-h-screen-safe bg-white text-gray-900 antialiased dark:bg-gray-950 dark:text-gray-50"
-      >
-      {/* 안전영역 패딩: iOS 노치/홈인디케이터 대응 */}
-      <div className="min-h-screen-safe pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left bg-red-50 mx-auto w-full max-w-screen-lg"> {/*TODO: bg-red-50 -> bg-main 변경 필요*/}
-        {children}
+      <html lang="ko" className={pacifico.variable}>
+      <body className="min-h-screen-safe bg-white text-gray-900 antialiased">
+
+      {/* ===== Color Shims: safe-area 배경을 강제로 'white'로 칠함 ===== */}
+      <div
+          className="fixed top-0 left-0 right-0 z-[60] bg-white dark:bg-gray-950"
+          style={{ height: "env(safe-area-inset-top, 0)" }}
+          aria-hidden
+      />
+      <div
+          className="fixed bottom-0 left-0 right-0 z-[60] bg-white dark:bg-gray-950"
+          style={{ height: "env(safe-area-inset-bottom, 0)" }}
+          aria-hidden
+      />
+      {/* =========================================================== */}
+
+      <div className="min-h-screen-safe pt-safe-top pr-safe-right pb-safe-bottom pl-safe-left">
+        <div className="mx-auto w-full max-w-screen-lg">
+          {children}
+        </div>
       </div>
+
       </body>
       </html>
   );

--- a/src/app/viewport.ts
+++ b/src/app/viewport.ts
@@ -5,6 +5,10 @@ const viewport: Viewport = {
   initialScale: 1,
   viewportFit: 'cover',
   maximumScale: 1,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" }, // 상단 바 흰색
+    { media: "(prefers-color-scheme: dark)",  color: "#0a0a0a" },
+  ],
 };
 
 export default viewport


### PR DESCRIPTION
…://github.com/Chuseok22/time-mate-web/issues/18

## ✨ 변경 사항
--- 
<!-- 핵심적으로 변경된 사항들을 간략하게 서술해주세요. -> 예시: S3 업로드 기능 추가 -->


## ✅ 테스트
---

- [ ] 수동 테스트 완료
- [ ] 테스트 코드 완료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 시스템 라이트/다크 모드에 따라 브라우저 상단 바 색상이 자동으로 적용됩니다.
* 스타일
  * 안전 영역(safe-area) 배경을 라이트/다크 모드에서 각각 흰색/진회색으로 일관되게 표시하도록 상·하단 고정 색상 레이어를 추가했습니다.
  * 바디 클래스 구성을 간소화하고 외곽 래퍼를 제거했으며, 콘텐츠는 최대 너비의 중앙 정렬 컨테이너로 유지됩니다.
* 리팩터
  * 레이아웃 구조를 단순화하고 불필요한 메타 구성을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->